### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#Bootstrap Tag Autocomplete
+# Bootstrap Tag Autocomplete
 
 This is a bootstrap plugin to autocomplete tags for contenteditable div elements. It works in the same way tagging people on Facebook, Twitter or Sandglaz works.
 
-#Demo and Documentation
+# Demo and Documentation
 
 <a href="http://sandglaz.github.com/bootstrap-tagautocomplete/">http://sandglaz.github.com/bootstrap-tagautocomplete/</a>
 
-#Contributing
+# Contributing
 
 <a href="https://github.com/Sandglaz/bootstrap-tagautocomplete/issues">Bug reports</a> and <a href="https://github.com/Sandglaz/bootstrap-tagautocomplete/pulls">pull requests</a> are welcomed! If your pull request contains JavaScript patches or features, you must include relevant unit tests.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
